### PR TITLE
chore: get ID from feed woocommerce

### DIFF
--- a/functions/lib/gmc-to-ecom.js
+++ b/functions/lib/gmc-to-ecom.js
@@ -199,7 +199,7 @@ const parseProduct = async (appSdk, appData, auth, storeId, feedProduct, product
     const categories = await getCategory(appSdk, storeId, feedProduct)
     const condition = getFeedValueByKey('condition', feedProduct)
     const newProductData = {
-      sku: (getFeedValueByKey('sku', feedProduct) || getFeedValueByKey('id', feedProduct)).toString(),
+      sku: (getFeedValueByKey('sku', feedProduct) || getFeedValueByKey('id', feedProduct) || getFeedValueByKey('ID', feedProduct)).toString(),
       name: getFeedValueByKey('title', feedProduct),
       subtitle: getFeedValueByKey('subtitle', feedProduct),
       meta_title: getFeedValueByKey('title', feedProduct),


### PR DESCRIPTION
@thiagoabreudev recebi um xml https://lojacontrotec.com.br/?woocommerce_gpf=google da woocommerce que lá usam g:ID e não o normal g:id, então não estava pegando o sku e assim, não era possível enviar produtos